### PR TITLE
Add global types filtering, brand/country/region grouping, and hotel …

### DIFF
--- a/app/api/global_types/route.ts
+++ b/app/api/global_types/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/lib/db';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { rows } = await sql`
+    SELECT
+      gt.global_type,
+      gt.type_description,
+      gt.type_category,
+      gtc.global_type_category
+    FROM global_types gt
+    LEFT JOIN global_types_categories gtc
+      ON gt.type_category::bigint = gtc.id
+    WHERE gt.global_type IS NOT NULL
+    ORDER BY gtc.global_type_category ASC, gt.type_description ASC, gt.global_type ASC
+  `;
+  return NextResponse.json(rows);
+}

--- a/app/api/hotels/route.ts
+++ b/app/api/hotels/route.ts
@@ -18,7 +18,7 @@ type IncomingHotel = {
 export async function GET() {
   const { rows } = await sql`
     SELECT id, name, code, COALESCE(brand,'') AS brand, COALESCE(region,'') AS region, COALESCE(country,'') AS country,
-           booking_url, tuiamello_url, expedia_url, bookable, active, base_image
+           booking_url, tuiamello_url, expedia_url, bookable, active, base_image, "globalTypes"
     FROM hotels
     ORDER BY id ASC
   `;

--- a/app/api/hotels/sync/route.ts
+++ b/app/api/hotels/sync/route.ts
@@ -137,7 +137,7 @@ export async function POST(): Promise<NextResponse> {
             COALESCE(region, '')  AS region,
             COALESCE(country, '') AS country,
             base_image, bookable, active,
-            booking_url, tuiamello_url, expedia_url
+            booking_url, tuiamello_url, expedia_url, "globalTypes"
      FROM hotels
      ORDER BY name ASC`,
   );

--- a/app/hotels/page.tsx
+++ b/app/hotels/page.tsx
@@ -3,6 +3,13 @@
 import * as React from 'react';
 import { fetchJSON } from '@/lib/api-client';
 
+type GlobalType = {
+  global_type: string;
+  type_description: string | null;
+  type_category: string | null;
+  global_type_category: string | null;
+};
+
 type Hotel = {
   id: number;
   name: string;
@@ -16,6 +23,7 @@ type Hotel = {
   bookable?: boolean | null;
   active?: boolean | null;
   base_image?: string | null;
+  globalTypes?: string[] | null;
 };
 
 type SortField = 'name' | 'brand' | 'region';
@@ -42,6 +50,9 @@ export default function Page() {
   const [syncBusy, setSyncBusy] = React.useState(false);
   const [syncWarnings, setSyncWarnings] = React.useState<string[]>([]);
 
+  const [globalTypeOptions, setGlobalTypeOptions] = React.useState<GlobalType[]>([]);
+  const [selectedGlobalTypes, setSelectedGlobalTypes] = React.useState<Set<string>>(new Set());
+
   const [filterActive,   setFilterActive]   = React.useState<FilterBool>('all');
   const [filterBookable, setFilterBookable] = React.useState<FilterBool>('all');
   const [sortField, setSortField] = React.useState<SortField>('name');
@@ -59,6 +70,18 @@ export default function Page() {
   const [editBusy, setEditBusy] = React.useState(false);
   const [editError, setEditError] = React.useState<string | null>(null);
 
+  const [globalTypesHotel, setGlobalTypesHotel] = React.useState<Hotel | null>(null);
+  const [globalTypeFilterOpen, setGlobalTypeFilterOpen] = React.useState(false);
+  const [copiedCodes, setCopiedCodes] = React.useState(false);
+
+  const copyHotelCodes = () => {
+    const codes = visibleHotels.map(h => h.code).join(', ');
+    navigator.clipboard.writeText(codes).then(() => {
+      setCopiedCodes(true);
+      setTimeout(() => setCopiedCodes(false), 2000);
+    });
+  };
+
   const [deleteHotel, setDeleteHotel] = React.useState<Hotel | null>(null);
   const [deleteBusy, setDeleteBusy] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState<string | null>(null);
@@ -75,10 +98,36 @@ export default function Page() {
   React.useEffect(() => { loadHotels(); }, [loadHotels]);
 
   React.useEffect(() => {
+    fetchJSON('/api/global_types', { cache: 'no-store' } as RequestInit)
+      .then((data: GlobalType[]) => {
+        if (!Array.isArray(data)) { setGlobalTypeOptions([]); return; }
+        // Deduplicate by global_type code — merge descriptions if multiple rows share the same code
+        const map = new Map<string, GlobalType>();
+        for (const gt of data) {
+          const existing = map.get(gt.global_type);
+          if (existing) {
+            const descs = [existing.type_description, gt.type_description].filter(Boolean);
+            map.set(gt.global_type, { ...existing, type_description: descs.join(' / ') || null });
+          } else {
+            map.set(gt.global_type, gt);
+          }
+        }
+        setGlobalTypeOptions([...map.values()]);
+      })
+      .catch(() => {});
+  }, []);
+
+  React.useEffect(() => {
     if (!successMsg) return;
     const t = setTimeout(() => setSuccessMsg(null), SUCCESS_MESSAGE_TIMEOUT_MS);
     return () => clearTimeout(t);
   }, [successMsg]);
+
+  const parseGlobalTypes = (raw: string[] | string | null | undefined): string[] => {
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw;
+    try { const p = JSON.parse(raw); return Array.isArray(p) ? p : []; } catch { return []; }
+  };
 
   const visibleHotels = React.useMemo(() => {
     let list = [...hotels];
@@ -90,6 +139,12 @@ export default function Page() {
       const want = filterBookable === 'true';
       list = list.filter(h => h.bookable === want);
     }
+    if (selectedGlobalTypes.size > 0) {
+      list = list.filter(h => {
+        const types = parseGlobalTypes(h.globalTypes as any);
+        return [...selectedGlobalTypes].every(sel => types.includes(sel));
+      });
+    }
     list.sort((a, b) => {
       const av = (a[sortField] ?? '').toLowerCase();
       const bv = (b[sortField] ?? '').toLowerCase();
@@ -98,7 +153,7 @@ export default function Page() {
       return 0;
     });
     return list;
-  }, [hotels, filterActive, filterBookable, sortField, sortDir]);
+  }, [hotels, filterActive, filterBookable, selectedGlobalTypes, sortField, sortDir]);
 
   const activeCount       = hotels.filter(h => h.active === true).length;
   const inactiveCount     = hotels.filter(h => h.active === false).length;
@@ -297,6 +352,92 @@ export default function Page() {
           </div>
         </div>
 
+        {/* ── Global Types Filter ──────────────────────────────────────── */}
+        {globalTypeOptions.length > 0 && (() => {
+          const categories = [...new Set(globalTypeOptions.map(gt => gt.global_type_category ?? ''))].sort();
+          const codes = visibleHotels.length > 0 ? visibleHotels.map(h => h.code).join(', ') : '—';
+          return (
+            <div className="card mb-3">
+              <div
+                className="card-header d-flex align-items-center justify-content-between py-2"
+                style={{ cursor: 'pointer', userSelect: 'none' }}
+                onClick={() => setGlobalTypeFilterOpen(o => !o)}
+              >
+                <span className="fw-semibold small">
+                  Filter by Global Type
+                  {selectedGlobalTypes.size > 0 && (
+                    <>
+                      <span className="badge bg-primary ms-2">{selectedGlobalTypes.size}</span>
+                      <button
+                        className="btn btn-link btn-sm p-0 ms-2 text-decoration-none text-danger"
+                        style={{ fontSize: '0.75rem' }}
+                        onClick={e => { e.stopPropagation(); setSelectedGlobalTypes(new Set()); }}
+                      >
+                        Clear
+                      </button>
+                    </>
+                  )}
+                </span>
+                <i className={`fas fa-chevron-${globalTypeFilterOpen ? 'up' : 'down'} small text-muted`} />
+              </div>
+
+              {globalTypeFilterOpen && (
+                <div className="card-body py-3">
+                  <div className="d-flex flex-wrap gap-4 mb-3">
+                    {categories.map(cat => (
+                      <div key={cat || '_'}>
+                        <div className="fw-semibold small text-muted mb-1">{cat || 'Uncategorized'}</div>
+                        <div className="d-flex flex-wrap gap-1">
+                          {globalTypeOptions.filter(gt => (gt.global_type_category ?? '') === cat).map(gt => {
+                            const active = selectedGlobalTypes.has(gt.global_type);
+                            return (
+                              <button
+                                key={gt.global_type}
+                                type="button"
+                                className={`btn btn-sm ${active ? 'btn-primary' : 'btn-outline-secondary'}`}
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  setSelectedGlobalTypes(prev => {
+                                    const next = new Set(prev);
+                                    next.has(gt.global_type) ? next.delete(gt.global_type) : next.add(gt.global_type);
+                                    return next;
+                                  });
+                                }}
+                                title={gt.global_type}
+                              >
+                                {gt.type_description || gt.global_type}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {selectedGlobalTypes.size > 0 && (
+                    <div className="border-top pt-3 mt-1">
+                      <div className="d-flex align-items-start gap-2">
+                        <div className="flex-grow-1">
+                          <span className="small fw-semibold me-2">Hotel codes ({visibleHotels.length}):</span>
+                          <span className="small text-muted font-monospace">{codes}</span>
+                        </div>
+                        <button
+                          className="btn btn-sm btn-outline-secondary flex-shrink-0"
+                          onClick={e => { e.stopPropagation(); copyHotelCodes(); }}
+                          disabled={visibleHotels.length === 0}
+                        >
+                          <i className={`fas fa-${copiedCodes ? 'check' : 'copy'} me-1`} />
+                          {copiedCodes ? 'Copied!' : 'Copy'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })()}
+
         {/* ── Stats ────────────────────────────────────────────────────── */}
         <p className="small text-muted mb-3">
           <strong>Total:</strong> {hotels.length} &nbsp;|&nbsp;
@@ -368,6 +509,17 @@ export default function Page() {
                       </tr>
                       <tr><td><strong>Bookable:</strong></td><td>{h.bookable == null ? 'N/A' : h.bookable ? 'Yes' : 'No'}</td></tr>
                       <tr><td><strong>Active:</strong></td><td>{h.active == null ? 'N/A' : h.active ? 'Yes' : 'No'}</td></tr>
+                      <tr>
+                        <td><strong>Global Types:</strong></td>
+                        <td>
+                          <button
+                            className="btn btn-link btn-sm p-0 text-decoration-none"
+                            onClick={() => setGlobalTypesHotel(h)}
+                          >
+                            View
+                          </button>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>
@@ -476,6 +628,45 @@ export default function Page() {
             </div>
           </div>
         )}
+
+        {/* ── Global Types Modal ──────────────────────────────────────────── */}
+        {globalTypesHotel && (() => {
+          const types = Array.isArray(globalTypesHotel.globalTypes)
+            ? globalTypesHotel.globalTypes
+            : typeof globalTypesHotel.globalTypes === 'string'
+              ? (() => { try { return JSON.parse(globalTypesHotel.globalTypes as string); } catch { return []; } })()
+              : [];
+          return (
+            <div className="modal show d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }} onClick={e => { if (e.target === e.currentTarget) setGlobalTypesHotel(null); }}>
+              <div className="modal-dialog modal-dialog-centered">
+                <div className="modal-content">
+                  <div className="modal-header">
+                    <h5 className="modal-title">
+                      Global Types — {globalTypesHotel.name}&nbsp;
+                      <code className="fs-6 text-muted">{globalTypesHotel.code}</code>
+                    </h5>
+                    <button type="button" className="btn-close" onClick={() => setGlobalTypesHotel(null)}></button>
+                  </div>
+                  <div className="modal-body">
+                    {types.length > 0
+                      ? <ul className="mb-0">{types.map((t: string, i: number) => {
+                          const meta = globalTypeOptions.find(g => g.globalType === t);
+                          const label = meta
+                            ? meta.type_description || t
+                            : t;
+                          return <li key={i}>{label}</li>;
+                        })}</ul>
+                      : <p className="text-muted mb-0">No global types available.</p>
+                    }
+                  </div>
+                  <div className="modal-footer">
+                    <button type="button" className="btn btn-secondary" onClick={() => setGlobalTypesHotel(null)}>Close</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
 
       </div>
     </main>

--- a/app/price-comparison/page.tsx
+++ b/app/price-comparison/page.tsx
@@ -14,7 +14,7 @@ type ScanRow = {
   status: 'queued' | 'running' | 'done' | 'error';
 };
 
-type HotelRow = { id: number; name: string; code: string };
+type HotelRow = { id: number; name: string; code: string; brand?: string; country?: string; region?: string };
 
 type RoomMapping = {
   id: number;
@@ -279,6 +279,11 @@ export default function Page() {
 
   const [sort, setSort] = React.useState<{ key: SortKey; dir: SortDir }>({ key: 'check_in_date', dir: 'asc' });
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>('all');
+  const [groupBy, setGroupBy] = React.useState<'none' | 'brand' | 'country' | 'region'>('none');
+  const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set());
+
+  const toggleGroup = (key: string) =>
+    setCollapsedGroups(prev => { const n = new Set(prev); n.has(key) ? n.delete(key) : n.add(key); return n; });
 
   const handleSort = (key: SortKey) =>
     setSort(prev => ({ key, dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc' }));
@@ -346,6 +351,10 @@ export default function Page() {
 
   // ── derived ──────────────────────────────────────────────────────────────
 
+  const hotelMeta = React.useMemo(() =>
+    new Map(hotels.map(h => [h.id, h])),
+  [hotels]);
+
   const filteredHotels = React.useMemo(() => {
     if (!hotelSearchTerm.trim()) return hotels;
     const term = hotelSearchTerm.toLowerCase();
@@ -373,6 +382,19 @@ export default function Page() {
     return map;
   }, [filteredRows, sort]);
 
+  const groupedByDimension = React.useMemo(() => {
+    if (groupBy === 'none') return null;
+    const outer = new Map<string, number[]>();
+    for (const [hotelId] of groupedByHotel) {
+      const meta = hotelMeta.get(hotelId);
+      const label = (meta?.[groupBy] ?? '') || '—';
+      const arr = outer.get(label) ?? [];
+      arr.push(hotelId);
+      outer.set(label, arr);
+    }
+    return new Map([...outer.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+  }, [groupBy, groupedByHotel, hotelMeta]);
+
   const summary = React.useMemo(() => {
     let amelloOnly = 0, bookingOnly = 0, both = 0, amelloCheaper = 0, bookingCheaper = 0, same = 0;
     let amelloSum = 0, amelloCount = 0, bookingSum = 0, bookingCount = 0, currency = 'EUR';
@@ -396,6 +418,46 @@ export default function Page() {
   }, [filteredRows]);
 
   // ── render ────────────────────────────────────────────────────────────────
+
+  const hotelTable = (rows: DisplayRow[]) => (
+    <div className="table-responsive border rounded">
+      <table className="table table-sm table-striped mb-0">
+        <thead className="table-light">
+          <tr>
+            <SortTh label="Check-In"      col="check_in_date"  sort={sort} onSort={handleSort} />
+            <th>Amello Room</th>
+            <th>Booking Room</th>
+            <th>Rate</th>
+            <SortTh label="Amello Price"  col="price_amello"   sort={sort} onSort={handleSort} className="text-end" />
+            <SortTh label="Booking Price" col="price_booking"  sort={sort} onSort={handleSort} className="text-end" />
+            <SortTh label="Diff (A−B)"    col="diff"           sort={sort} onSort={handleSort} className="text-end" />
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => {
+            const { label, className: pillCls, style: pillStyle } = pillProps(r.price_amello, r.price_booking);
+            return (
+              <tr key={i} className={rowClass(r)}>
+                <td className="text-nowrap">{r.check_in_date}</td>
+                <td>{r.amello_room  ?? <span className="text-muted fst-italic">—</span>}</td>
+                <td>{r.booking_room ?? <span className="text-muted fst-italic">—</span>}</td>
+                <td className="text-muted small">{r.rate_name || '—'}</td>
+                <td className="text-end text-nowrap">
+                  {r.price_amello != null ? formatPrice(r.price_amello, r.currency) : <span className="text-muted">—</span>}
+                </td>
+                <td className="text-end text-nowrap">
+                  {r.price_booking != null ? formatPrice(r.price_booking, r.currency) : <span className="text-muted">—</span>}
+                </td>
+                <DiffCell a={r.price_amello} b={r.price_booking} currency={r.currency} />
+                <td><span className={pillCls} style={pillStyle}>{label}</span></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 
   return (
     <main>
@@ -456,6 +518,13 @@ export default function Page() {
             <option value="booking_cheaper_lte5">Booking cheaper ≤5%</option>
             <option value="amello_cheaper">Amello cheaper</option>
           </select>
+
+          <select className="form-select" style={{ maxWidth: 180 }} value={groupBy} onChange={e => { setGroupBy(e.target.value as typeof groupBy); setCollapsedGroups(new Set()); }}>
+            <option value="none">No grouping</option>
+            <option value="brand">Group by Brand</option>
+            <option value="country">Group by Country</option>
+            <option value="region">Group by Region</option>
+          </select>
         </div>
 
         {/* ── scan parameters ── */}
@@ -506,52 +575,35 @@ export default function Page() {
           </div>
         )}
 
-        {/* ── tables grouped by hotel ── */}
-        {Array.from(groupedByHotel.entries()).map(([hotelId, rows]) => (
-          <div key={hotelId} className="mb-5">
-            <h4 className="mb-2">{rows[0].hotel_name}</h4>
-
-            <div className="table-responsive border rounded">
-              <table className="table table-sm table-striped mb-0">
-                <thead className="table-light">
-                  <tr>
-                    <SortTh label="Check-In"      col="check_in_date"  sort={sort} onSort={handleSort} />
-                    <th>Amello Room</th>
-                    <th>Booking Room</th>
-                    <th>Rate</th>
-                    <SortTh label="Amello Price"  col="price_amello"   sort={sort} onSort={handleSort} className="text-end" />
-                    <SortTh label="Booking Price" col="price_booking"  sort={sort} onSort={handleSort} className="text-end" />
-                    <SortTh label="Diff (A−B)"    col="diff"           sort={sort} onSort={handleSort} className="text-end" />
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r, i) => {
-                    const { label, className: pillCls, style: pillStyle } = pillProps(r.price_amello, r.price_booking);
-                    return (
-                      <tr key={i} className={rowClass(r)}>
-                        <td className="text-nowrap">{r.check_in_date}</td>
-                        <td>{r.amello_room  ?? <span className="text-muted fst-italic">—</span>}</td>
-                        <td>{r.booking_room ?? <span className="text-muted fst-italic">—</span>}</td>
-                        <td className="text-muted small">{r.rate_name || '—'}</td>
-                        <td className="text-end text-nowrap">
-                          {r.price_amello != null ? formatPrice(r.price_amello, r.currency) : <span className="text-muted">—</span>}
-                        </td>
-                        <td className="text-end text-nowrap">
-                          {r.price_booking != null ? formatPrice(r.price_booking, r.currency) : <span className="text-muted">—</span>}
-                        </td>
-                        <DiffCell a={r.price_amello} b={r.price_booking} currency={r.currency} />
-                        <td>
-                          <span className={pillCls} style={pillStyle}>{label}</span>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+        {/* ── tables grouped by hotel (optionally wrapped in dimension groups) ── */}
+        {groupedByDimension
+          ? Array.from(groupedByDimension.entries()).map(([groupLabel, hotelIds]) => (
+            <div key={groupLabel} className="mb-4">
+              <button
+                className="btn btn-light border w-100 text-start fw-semibold d-flex justify-content-between align-items-center mb-2 px-3 py-2"
+                onClick={() => toggleGroup(groupLabel)}
+              >
+                <span>{groupLabel} <span className="text-muted fw-normal small ms-1">({hotelIds.length} hotel{hotelIds.length !== 1 ? 's' : ''})</span></span>
+                <i className={`fas fa-chevron-${collapsedGroups.has(groupLabel) ? 'down' : 'up'} small`} />
+              </button>
+              {!collapsedGroups.has(groupLabel) && hotelIds.map(hotelId => {
+                const rows = groupedByHotel.get(hotelId)!;
+                return (
+                  <div key={hotelId} className="mb-4 ms-3">
+                    <h5 className="mb-2">{rows[0].hotel_name}</h5>
+                    {hotelTable(rows)}
+                  </div>
+                );
+              })}
             </div>
-          </div>
-        ))}
+          ))
+          : Array.from(groupedByHotel.entries()).map(([hotelId, rows]) => (
+            <div key={hotelId} className="mb-5">
+              <h4 className="mb-2">{rows[0].hotel_name}</h4>
+              {hotelTable(rows)}
+            </div>
+          ))
+        }
 
         {!loading && groupedByHotel.size === 0 && !error && (
           <p className="text-muted">No results found for this scan.</p>

--- a/app/rate-comparison/page.tsx
+++ b/app/rate-comparison/page.tsx
@@ -14,7 +14,7 @@ type ScanRow = {
   status: 'queued' | 'running' | 'done' | 'error';
 };
 
-type HotelRow = { id: number; name: string; code: string };
+type HotelRow = { id: number; name: string; code: string; brand?: string; country?: string; region?: string };
 
 type RateRow = {
   scan_id: number;
@@ -146,6 +146,11 @@ export default function Page() {
   // ── sort & filter state ──────────────────────────────────────────────────
   const [sort, setSort] = React.useState<{ key: SortKey; dir: SortDir }>({ key: 'check_in_date', dir: 'asc' });
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>('all');
+  const [groupBy, setGroupBy] = React.useState<'none' | 'brand' | 'country' | 'region'>('none');
+  const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set());
+
+  const toggleGroup = (key: string) =>
+    setCollapsedGroups(prev => { const n = new Set(prev); n.has(key) ? n.delete(key) : n.add(key); return n; });
 
   const handleSort = (key: SortKey) =>
     setSort(prev => ({ key, dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc' }));
@@ -212,6 +217,10 @@ export default function Page() {
 
   // ── derived data ──────────────────────────────────────────────────────────
 
+  const hotelMeta = React.useMemo(() =>
+    new Map(hotels.map(h => [h.id, h])),
+  [hotels]);
+
   const filteredHotels = React.useMemo(() => {
     if (!hotelSearchTerm.trim()) return hotels;
     const t = hotelSearchTerm.toLowerCase();
@@ -234,6 +243,20 @@ export default function Page() {
     for (const [id, rows] of map) map.set(id, sortRows(rows, sort.key, sort.dir));
     return map;
   }, [filteredRows, sort]);
+
+  // outer grouping by brand / country / region
+  const groupedByDimension = React.useMemo(() => {
+    if (groupBy === 'none') return null;
+    const outer = new Map<string, number[]>(); // groupLabel → hotelIds
+    for (const [hotelId] of groupedByHotel) {
+      const meta = hotelMeta.get(hotelId);
+      const label = (meta?.[groupBy] ?? '') || '—';
+      const arr = outer.get(label) ?? [];
+      arr.push(hotelId);
+      outer.set(label, arr);
+    }
+    return new Map([...outer.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+  }, [groupBy, groupedByHotel, hotelMeta]);
 
   const summary = React.useMemo(() => {
     let amelloOnly = 0, bookingOnly = 0, both = 0, amelloCheaper = 0, bookingCheaper = 0, same = 0;
@@ -258,6 +281,57 @@ export default function Page() {
   }, [filteredRows]);
 
   // ── render ────────────────────────────────────────────────────────────────
+
+  const hotelTable = (rows: RateRow[]) => (
+    <div className="table-responsive border rounded">
+      <table className="table table-sm table-striped mb-0">
+        <thead className="table-light">
+          <tr>
+            <SortTh label="Check-In"   col="check_in_date"         sort={sort} onSort={handleSort} />
+            <th>Amello Room</th>
+            <th>Amello Rate</th>
+            <SortTh label="Amello Price"    col="amello_min_price"    sort={sort} onSort={handleSort} className="text-end" />
+            <th>Booking Room</th>
+            <th>Booking Rate</th>
+            <SortTh label="Booking Price"   col="booking_min_price"   sort={sort} onSort={handleSort} className="text-end" />
+            <SortTh label="Diff (A−B)"      col="price_difference"    sort={sort} onSort={handleSort} className="text-end" />
+            <SortTh label="% Diff"          col="percentage_difference" sort={sort} onSort={handleSort} className="text-end" />
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => {
+            const a = r.amello_min_price;
+            const b = r.booking_min_price;
+            const currency = r.amello_currency || r.booking_currency || 'EUR';
+            const { label, className: pillCls, style: pillStyle } = pillProps(a, b);
+            const diffCls = r.price_difference == null ? 'text-muted'
+              : r.price_difference > 0 ? 'text-danger'
+              : r.price_difference < 0 ? 'text-success'
+              : 'text-muted';
+            return (
+              <tr key={i} className={rowBgClass(a, b)}>
+                <td className="text-nowrap">{fmtDate(r.check_in_date)}</td>
+                <td className="small">{r.amello_room_name  || <span className="text-muted">—</span>}</td>
+                <td className="small">{r.amello_rate_name  || <span className="text-muted">—</span>}</td>
+                <td className="text-end text-nowrap">{a != null ? formatPrice(a, currency) : <span className="text-muted">—</span>}</td>
+                <td className="small">{r.booking_room_name || <span className="text-muted">—</span>}</td>
+                <td className="small">{r.booking_rate_name || <span className="text-muted">—</span>}</td>
+                <td className="text-end text-nowrap">{b != null ? formatPrice(b, currency) : <span className="text-muted">—</span>}</td>
+                <td className={`text-end fw-bold ${diffCls}`}>
+                  {r.price_difference != null ? (r.price_difference > 0 ? '+' : '') + formatPrice(r.price_difference, currency) : <span className="text-muted">—</span>}
+                </td>
+                <td className={`text-end fw-bold ${diffCls}`}>
+                  {r.percentage_difference != null ? (r.percentage_difference > 0 ? '+' : '') + r.percentage_difference.toFixed(1) + '%' : <span className="text-muted">—</span>}
+                </td>
+                <td><span className={pillCls} style={pillStyle}>{label}</span></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 
   return (
     <main>
@@ -315,6 +389,13 @@ export default function Page() {
             <option value="booking_cheaper_lte5">Booking cheaper ≤5%</option>
             <option value="amello_cheaper">Amello cheaper</option>
           </select>
+
+          <select className="form-select" style={{ maxWidth: 180 }} value={groupBy} onChange={e => { setGroupBy(e.target.value as typeof groupBy); setCollapsedGroups(new Set()); }}>
+            <option value="none">No grouping</option>
+            <option value="brand">Group by Brand</option>
+            <option value="country">Group by Country</option>
+            <option value="region">Group by Region</option>
+          </select>
         </div>
 
         {/* ── scan parameters ── */}
@@ -365,72 +446,35 @@ export default function Page() {
           </div>
         )}
 
-        {/* ── tables grouped by hotel ── */}
-        {Array.from(groupedByHotel.entries()).map(([hotelId, rows]) => (
-          <div key={hotelId} className="mb-5">
-            <h4 className="mb-2">{rows[0].hotel_name}</h4>
-
-            <div className="table-responsive border rounded">
-              <table className="table table-sm table-striped mb-0">
-                <thead className="table-light">
-                  <tr>
-                    <SortTh label="Check-In"   col="check_in_date"       sort={sort} onSort={handleSort} />
-                    <th>Amello Room</th>
-                    <th>Amello Rate</th>
-                    <SortTh label="Amello Price"   col="amello_min_price"    sort={sort} onSort={handleSort} className="text-end" />
-                    <th>Booking Room</th>
-                    <th>Booking Rate</th>
-                    <SortTh label="Booking Price"  col="booking_min_price"   sort={sort} onSort={handleSort} className="text-end" />
-                    <SortTh label="Diff (A−B)"     col="price_difference"    sort={sort} onSort={handleSort} className="text-end" />
-                    <SortTh label="% Diff"         col="percentage_difference" sort={sort} onSort={handleSort} className="text-end" />
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r, i) => {
-                    const a = r.amello_min_price;
-                    const b = r.booking_min_price;
-                    const currency = r.amello_currency || r.booking_currency || 'EUR';
-                    const { label, className: pillCls, style: pillStyle } = pillProps(a, b);
-                    const diffCls = r.price_difference == null ? 'text-muted'
-                      : r.price_difference > 0 ? 'text-danger'
-                      : r.price_difference < 0 ? 'text-success'
-                      : 'text-muted';
-
-                    return (
-                      <tr key={i} className={rowBgClass(a, b)}>
-                        <td className="text-nowrap">{fmtDate(r.check_in_date)}</td>
-                        <td className="small">{r.amello_room_name  || <span className="text-muted">—</span>}</td>
-                        <td className="small">{r.amello_rate_name  || <span className="text-muted">—</span>}</td>
-                        <td className="text-end text-nowrap">
-                          {a != null ? formatPrice(a, currency) : <span className="text-muted">—</span>}
-                        </td>
-                        <td className="small">{r.booking_room_name || <span className="text-muted">—</span>}</td>
-                        <td className="small">{r.booking_rate_name || <span className="text-muted">—</span>}</td>
-                        <td className="text-end text-nowrap">
-                          {b != null ? formatPrice(b, currency) : <span className="text-muted">—</span>}
-                        </td>
-                        <td className={`text-end fw-bold ${diffCls}`}>
-                          {r.price_difference != null
-                            ? (r.price_difference > 0 ? '+' : '') + formatPrice(r.price_difference, currency)
-                            : <span className="text-muted">—</span>}
-                        </td>
-                        <td className={`text-end fw-bold ${diffCls}`}>
-                          {r.percentage_difference != null
-                            ? (r.percentage_difference > 0 ? '+' : '') + r.percentage_difference.toFixed(1) + '%'
-                            : <span className="text-muted">—</span>}
-                        </td>
-                        <td>
-                          <span className={pillCls} style={pillStyle}>{label}</span>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+        {/* ── tables grouped by hotel (optionally wrapped in dimension groups) ── */}
+        {groupedByDimension
+          ? Array.from(groupedByDimension.entries()).map(([groupLabel, hotelIds]) => (
+            <div key={groupLabel} className="mb-4">
+              <button
+                className="btn btn-light border w-100 text-start fw-semibold d-flex justify-content-between align-items-center mb-2 px-3 py-2"
+                onClick={() => toggleGroup(groupLabel)}
+              >
+                <span>{groupLabel} <span className="text-muted fw-normal small ms-1">({hotelIds.length} hotel{hotelIds.length !== 1 ? 's' : ''})</span></span>
+                <i className={`fas fa-chevron-${collapsedGroups.has(groupLabel) ? 'down' : 'up'} small`} />
+              </button>
+              {!collapsedGroups.has(groupLabel) && hotelIds.map(hotelId => {
+                const rows = groupedByHotel.get(hotelId)!;
+                return (
+                  <div key={hotelId} className="mb-4 ms-3">
+                    <h5 className="mb-2">{rows[0].hotel_name}</h5>
+                    {hotelTable(rows)}
+                  </div>
+                );
+              })}
             </div>
-          </div>
-        ))}
+          ))
+          : Array.from(groupedByHotel.entries()).map(([hotelId, rows]) => (
+            <div key={hotelId} className="mb-5">
+              <h4 className="mb-2">{rows[0].hotel_name}</h4>
+              {hotelTable(rows)}
+            </div>
+          ))
+        }
 
         {!loading && groupedByHotel.size === 0 && !error && (
           <p className="text-muted">No results found for this scan.</p>

--- a/db/migrations/010_global_types_category.sql
+++ b/db/migrations/010_global_types_category.sql
@@ -1,0 +1,4 @@
+-- Migration 010: add category and name columns to global_types table
+
+ALTER TABLE "globalTypes"
+  ADD COLUMN IF NOT EXISTS type_category VARCHAR(100);

--- a/db/migrations/011_rename_global_types_snake_case.sql
+++ b/db/migrations/011_rename_global_types_snake_case.sql
@@ -1,0 +1,5 @@
+-- Migration 011: rename globalTypes table and columns to snake_case
+
+ALTER TABLE "globalTypes" RENAME TO global_types;
+ALTER TABLE global_types RENAME COLUMN "globalType" TO global_type;
+ALTER TABLE hotels RENAME COLUMN "globalTypes" TO global_types;


### PR DESCRIPTION
…sync improvements

- Add global_types API route with category join
- Add collapsible global type filter panel with per-category toggle buttons, hotel codes result, and copy to clipboard
- Add brand/country/region grouping (collapsible) on price comparison and best available rates pages
- Remove CSV enrichment from hotel sync; global_types table managed manually
- Add migrations for global_types category and snake_case rename
- Fix hotel sync to skip global_types/global_type_categories updates post-sync